### PR TITLE
Knob Goblin Embezzler is NOCOPY. Check OnlyFax first.

### DIFF
--- a/scripts/VeracityMeatFarm.ash
+++ b/scripts/VeracityMeatFarm.ash
@@ -682,7 +682,7 @@ string_list deck_cards = define_property( "VMF.DeckCards", "string", "Island|Anc
 
 // Which monster to fax in to a photocopied monster
 
-monster fax_monster = define_property( "VMF.FaxMonster", "monster", "Knob Goblin Embezzler" ).to_monster();
+monster fax_monster = define_property( "VMF.FaxMonster", "monster", "none" ).to_monster();
 
 // Reason for faxing monster
 //
@@ -8827,6 +8827,7 @@ boolean get_fax( monster enemy )
     string choose_faxbot()
     {
 	return
+	    check_faxbot( "OnlyFax" ) ? "OnlyFax" :
 	    check_faxbot( "EasyFax" ) ? "EasyFax" :
 	    check_faxbot( "CheeseFax" ) ? "CheeseFax" :
 	    "";


### PR DESCRIPTION
You can no longer fax in a Knob Goblin Embezzler.
I don't have auniversal  good replacement; my characters are using a pumpkin spice wraith, for the 1 in 1000 chance to get a pumpkin spice whorl, but other users may have a different idea of what they want.

I've had issues with EasyFax recently; even though I can see monsters in its published catalog, when I try to fax them, KoLmafia says they are not available. The list displays strangely, with HTML monsterId markup. Perhaps it is a KoLmafia issue?

So, I added OnlyFax - whose monsterId info seems more rational - and which works better for me, at the moment - as the first faxbot to check.